### PR TITLE
Disable console window for Windows builds.

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,6 +3,9 @@ name = "client"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+console = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(
+    all(target_os = "windows", not(feature = "console")),
+    windows_subsystem = "windows"
+)]
+
 use std::sync::mpsc::{channel, Sender};
 
 use clash::protocol::{Connection, Message};


### PR DESCRIPTION
Simple PR to prevent the app from opening a console window on Windows builds. I have added a cargo feature to allow enabling the console at compile time as it may prove useful in the future for debugging with real players. 