### PR TITLE
Fix `written amount not handled` lint

### DIFF
--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -22,8 +22,7 @@ impl State {
     }
 
     pub fn add_player(&mut self) -> PlayerId {
-        let player_id = self.gen_player_id();
-        player_id
+        self.gen_player_id()
     }
 
     pub fn add_lobby(&mut self) -> LobbyId {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -141,7 +141,7 @@ impl Connection {
         }
         let len = bytes.len() as u16;
         let len = len.to_be_bytes();
-        self.write_stream.write(&len).await?;
+        self.write_stream.write_all(&len).await?;
         self.write_stream.write_buf(&mut bytes).await?;
         self.write_stream.flush().await?;
         Ok(())


### PR DESCRIPTION
Closes #23

We don't actually have to worry about cancellation safety here as the only futures that will be cancelled by the server's `select` block are either the `read_frame` call or the `recv` call on `lobby_recv`. The future that executes this code is only started after the `recv` future completes, so we don't have to worry about the future executing this code being cancelled by the select macro.

This is admittedly a bit of a brain-bender to think about and there's probably a better way to structure our code to handle this stuff more cleanly so consider this a bit of a band-aid fix I guess.