### PR TITLE
Various refactorings.

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,8 +1,4 @@
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: pull_request
 
 name: Continuous Integration
 
@@ -15,6 +11,11 @@ jobs:
     name: Continuous Integration - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install C build-dependencies
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt update -qq
+          sudo apt install -y libxcb-shape0-dev libxcb-xfixes0-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -23,15 +24,23 @@ jobs:
           override: true
       - run: rustup component add rustfmt
       - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
+      - name: Verify formatting
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-      - uses: actions-rs/cargo@v1
+      - name: Verify build
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --all
-      - uses: actions-rs/cargo@v1
+      - name: Deny Clippy warnings
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all -- -D warnings
+      - name: Run Tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
                 "args": [
                     "build",
                     "--bin=client",
-                    "--package=client"
+                    "--package=client",
+                    "--features=console"
                 ],
                 "filter": {
                     "name": "client",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,101 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug Client",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=client",
+                    "--package=client"
+                ],
+                "filter": {
+                    "name": "client",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug Server",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=server",
+                    "--package=server"
+                ],
+                "filter": {
+                    "name": "server",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'client'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=client",
+                    "--package=client"
+                ],
+                "filter": {
+                    "name": "client",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'server'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=server",
+                    "--package=server"
+                ],
+                "filter": {
+                    "name": "server",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'clash'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=clash"
+                ],
+                "filter": {
+                    "name": "clash",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
  "bfbb",
  "bincode",
  "bytes",
- "egui",
+ "epaint",
  "log",
  "serde",
  "thiserror",
@@ -911,6 +911,7 @@ dependencies = [
  "bytemuck",
  "emath",
  "nohash-hasher",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = ["client", "server"]
 [dependencies]
 bfbb = { version = "0.1", features = ["serde"]}
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "net", "macros"] }
-egui = "0.17"
+epaint = "0.17"
 
 bincode = "1"
 bytes = "1"

--- a/client/src/game/game_mode.rs
+++ b/client/src/game/game_mode.rs
@@ -1,0 +1,17 @@
+use bfbb::game_interface::GameInterface;
+use clash::{lobby::NetworkedLobby, net::Message, PlayerId};
+
+// TODO: Revisit this when new unique game modes are created.
+//  Idea is to allow game mode logic to be implemented by an arbitrary
+//  struct with a consistent interface.
+pub trait GameMode {
+    type Result;
+
+    fn update<G: GameInterface>(
+        &mut self,
+        interface: &G,
+        lobby: &mut NetworkedLobby,
+        local_player: PlayerId,
+        network_sender: &mut tokio::sync::mpsc::Sender<Message>,
+    ) -> Self::Result;
+}

--- a/client/src/game/game_state.rs
+++ b/client/src/game/game_state.rs
@@ -1,5 +1,5 @@
 use crate::game::{GameInterface, InterfaceResult};
-use bfbb::{IntoEnumIterator, Level, Spatula};
+use bfbb::{IntoEnumIterator, Spatula};
 use clash::lobby::{GamePhase, NetworkedLobby};
 use clash::net::{Item, Message};
 use clash::PlayerId;
@@ -14,8 +14,6 @@ pub trait GameStateExt {
         game: &T,
         network_sender: &mut tokio::sync::mpsc::Sender<Message>,
     ) -> InterfaceResult<()>;
-
-    fn can_start(&self) -> bool;
 }
 
 impl GameStateExt for NetworkedLobby {
@@ -91,16 +89,5 @@ impl GameStateExt for NetworkedLobby {
         }
 
         Ok(())
-    }
-
-    /// True when all connected players are on the Main Menu
-    fn can_start(&self) -> bool {
-        // TODO: Solve the "Demo Cutscene" issue. We can probably detect when players are on the autosave preference screen instead.
-        for player in self.players.values() {
-            if player.current_level != Some(Level::MainMenu) {
-                return false;
-            }
-        }
-        true
     }
 }

--- a/client/src/game/game_state.rs
+++ b/client/src/game/game_state.rs
@@ -1,7 +1,7 @@
 use crate::game::{GameInterface, InterfaceResult};
 use bfbb::{IntoEnumIterator, Level, Spatula};
 use clash::lobby::{GamePhase, NetworkedLobby};
-use clash::protocol::{Item, Message};
+use clash::net::{Item, Message};
 use clash::PlayerId;
 use log::info;
 

--- a/client/src/game/game_state.rs
+++ b/client/src/game/game_state.rs
@@ -1,6 +1,6 @@
 use crate::game::{GameInterface, InterfaceResult};
 use bfbb::{IntoEnumIterator, Level, Spatula};
-use clash::lobby::{GamePhase, SharedLobby};
+use clash::lobby::{GamePhase, NetworkedLobby};
 use clash::protocol::{Item, Message};
 use clash::PlayerId;
 use log::info;
@@ -18,7 +18,7 @@ pub trait GameStateExt {
     fn can_start(&self) -> bool;
 }
 
-impl GameStateExt for SharedLobby {
+impl GameStateExt for NetworkedLobby {
     /// Process state updates from the server and report back any actions of the local player
     fn update<T: GameInterface>(
         &mut self,

--- a/client/src/game/mod.rs
+++ b/client/src/game/mod.rs
@@ -6,7 +6,7 @@ use bfbb::game_interface::{
     dolphin::DolphinInterface, GameInterface, InterfaceError, InterfaceResult,
 };
 use clash::{
-    lobby::{GamePhase, SharedLobby},
+    lobby::{GamePhase, NetworkedLobby},
     protocol::Message,
     PlayerId,
 };
@@ -15,7 +15,7 @@ use spin_sleep::LoopHelper;
 use std::sync::mpsc::{Receiver, Sender};
 
 pub fn start_game(
-    mut gui_sender: Sender<(PlayerId, SharedLobby)>,
+    mut gui_sender: Sender<(PlayerId, NetworkedLobby)>,
     mut network_sender: tokio::sync::mpsc::Sender<Message>,
     mut logic_receiver: Receiver<Message>,
 ) {
@@ -71,9 +71,9 @@ pub fn start_game(
 fn update_from_network<T: GameInterface>(
     game: &T,
     player_id: &mut PlayerId,
-    lobby: &mut Option<SharedLobby>,
+    lobby: &mut Option<NetworkedLobby>,
     logic_receiver: &mut Receiver<Message>,
-    gui_sender: &mut Sender<(PlayerId, SharedLobby)>,
+    gui_sender: &mut Sender<(PlayerId, NetworkedLobby)>,
 ) -> Result<(), InterfaceError> {
     while let Ok(m) = logic_receiver.try_recv() {
         match m {

--- a/client/src/game/mod.rs
+++ b/client/src/game/mod.rs
@@ -7,7 +7,7 @@ use bfbb::game_interface::{
 };
 use clash::{
     lobby::{GamePhase, NetworkedLobby},
-    protocol::Message,
+    net::Message,
     PlayerId,
 };
 use log::error;

--- a/client/src/game/mod.rs
+++ b/client/src/game/mod.rs
@@ -49,16 +49,14 @@ pub fn start_game(
                 lobby.update(player_id, &game, &mut network_sender)
             {
                 // We lost dolphin
-                || -> Option<()> {
-                    let local_player = lobby.players.get_mut(&player_id)?;
+                if let Some(local_player) = lobby.players.get_mut(&player_id) {
                     if local_player.current_level != None {
                         local_player.current_level = None;
                         network_sender
                             .blocking_send(Message::GameCurrentLevel { level: None })
                             .unwrap();
                     }
-                    Some(())
-                }();
+                }
 
                 // TODO: Maybe don't re-attempt this every frame
                 let _ = game.hook();

--- a/client/src/gui/game_menu.rs
+++ b/client/src/gui/game_menu.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use bfbb::{IntoEnumIterator, Spatula};
-use clash::{game_state::GameState, player::SharedPlayer, PlayerId};
+use clash::{game_state::GameState, player::NetworkedPlayer, PlayerId};
 use eframe::{
     egui::{Color32, Response, Sense, Ui, Widget},
     epaint::Vec2,
@@ -9,11 +9,11 @@ use eframe::{
 
 pub struct GameMenu<'a> {
     game: &'a GameState,
-    players: &'a HashMap<PlayerId, SharedPlayer>,
+    players: &'a HashMap<PlayerId, NetworkedPlayer>,
 }
 
 impl<'a> GameMenu<'a> {
-    pub fn new(game: &'a GameState, players: &'a HashMap<PlayerId, SharedPlayer>) -> Self {
+    pub fn new(game: &'a GameState, players: &'a HashMap<PlayerId, NetworkedPlayer>) -> Self {
         Self { game, players }
     }
 }

--- a/client/src/gui/mod.rs
+++ b/client/src/gui/mod.rs
@@ -4,7 +4,7 @@ mod player_widget;
 use crate::game::GameStateExt;
 
 use self::{game_menu::GameMenu, player_widget::PlayerUi};
-use clash::lobby::{GamePhase, LobbyOptions, SharedLobby};
+use clash::lobby::{GamePhase, LobbyOptions, NetworkedLobby};
 use clash::player::PlayerOptions;
 use clash::protocol::Message;
 use clash::PlayerId;
@@ -30,7 +30,7 @@ pub enum Menu {
 }
 
 pub struct Clash {
-    gui_receiver: Receiver<(PlayerId, SharedLobby)>,
+    gui_receiver: Receiver<(PlayerId, NetworkedLobby)>,
     network_sender: tokio::sync::mpsc::Sender<Message>,
     error_receiver: Receiver<Box<dyn Error + Send>>,
 
@@ -46,14 +46,14 @@ pub struct Clash {
     lab_door_num: Option<u8>,
 
     player_id: PlayerId,
-    lobby: SharedLobby,
+    lobby: NetworkedLobby,
 
     error_queue: Vec<Box<dyn Error>>,
 }
 
 impl Clash {
     fn new(
-        gui_receiver: Receiver<(PlayerId, SharedLobby)>,
+        gui_receiver: Receiver<(PlayerId, NetworkedLobby)>,
         error_receiver: Receiver<Box<dyn Error + Send>>,
         network_sender: tokio::sync::mpsc::Sender<Message>,
     ) -> Self {
@@ -69,7 +69,7 @@ impl Clash {
             lab_door_buf: Default::default(),
             lab_door_num: None,
             player_id: 0,
-            lobby: SharedLobby::new(0, LobbyOptions::default()),
+            lobby: NetworkedLobby::new(0, LobbyOptions::default()),
             error_queue: Vec::new(),
         }
     }
@@ -381,7 +381,7 @@ impl App for Clash {
 }
 
 pub fn run(
-    gui_receiver: Receiver<(PlayerId, SharedLobby)>,
+    gui_receiver: Receiver<(PlayerId, NetworkedLobby)>,
     error_receiver: Receiver<Box<dyn Error + Send>>,
     network_sender: tokio::sync::mpsc::Sender<Message>,
 ) {

--- a/client/src/gui/mod.rs
+++ b/client/src/gui/mod.rs
@@ -5,8 +5,8 @@ use crate::game::GameStateExt;
 
 use self::{game_menu::GameMenu, player_widget::PlayerUi};
 use clash::lobby::{GamePhase, LobbyOptions, NetworkedLobby};
+use clash::net::Message;
 use clash::player::PlayerOptions;
-use clash::protocol::Message;
 use clash::PlayerId;
 use std::error::Error;
 use std::sync::mpsc::Receiver;

--- a/client/src/gui/mod.rs
+++ b/client/src/gui/mod.rs
@@ -1,8 +1,6 @@
 mod game_menu;
 mod player_widget;
 
-use crate::game::GameStateExt;
-
 use self::{game_menu::GameMenu, player_widget::PlayerUi};
 use clash::lobby::{GamePhase, LobbyOptions, NetworkedLobby};
 use clash::net::Message;

--- a/client/src/gui/player_widget.rs
+++ b/client/src/gui/player_widget.rs
@@ -1,13 +1,13 @@
 use bfbb::Level;
-use clash::player::SharedPlayer;
+use clash::player::NetworkedPlayer;
 use eframe::egui::{Response, Sense, Stroke, TextStyle, Ui, Vec2, Widget};
 
 pub struct PlayerUi<'a> {
-    player: &'a SharedPlayer,
+    player: &'a NetworkedPlayer,
 }
 
 impl<'a> PlayerUi<'a> {
-    pub fn new(player: &'a SharedPlayer) -> Self {
+    pub fn new(player: &'a NetworkedPlayer) -> Self {
         Self { player }
     }
 }

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -8,7 +8,7 @@ use std::{
     sync::mpsc::{channel, Sender},
 };
 
-use clash::protocol::{Connection, Message, ProtocolError};
+use clash::net::{Connection, Message, ProtocolError};
 use log::{debug, error, info};
 use tokio::{net::TcpStream, select};
 

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -2,7 +2,7 @@ use crate::state::State;
 use anyhow::Context;
 use bfbb::Spatula;
 use clash::lobby::GamePhase;
-use clash::protocol::{self, Connection, Item, Message, ProtocolError};
+use clash::net::{Connection, FrameError, Item, Message, ProtocolError};
 use clash::PlayerId;
 use std::collections::hash_map::Entry;
 use std::sync::{Arc, RwLock};
@@ -18,10 +18,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn new(
-        state: Arc<RwLock<State>>,
-        socket: TcpStream,
-    ) -> Result<Self, protocol::FrameError> {
+    pub async fn new(state: Arc<RwLock<State>>, socket: TcpStream) -> Result<Self, FrameError> {
         // Add new player
         let player_id = {
             let mut state = state.write().unwrap();

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -145,7 +145,14 @@ impl Client {
             Message::GameBegin => {
                 let state = &mut *self.state.write().unwrap();
                 let lobby = state.get_lobby(self.player_id)?;
-                lobby.start_game();
+                if lobby.shared.can_start() {
+                    lobby.start_game();
+                } else {
+                    log::warn!(
+                        "Lobby {:#X} attempted to start when some players aren't on the Main Menu",
+                        lobby.shared.lobby_id
+                    )
+                }
             }
             Message::GameLeave => {
                 // Remove player from their lobby

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -1,5 +1,5 @@
-use clash::lobby::{GamePhase, LobbyOptions, SharedLobby};
-use clash::player::{PlayerOptions, SharedPlayer};
+use clash::lobby::{GamePhase, LobbyOptions, NetworkedLobby};
+use clash::player::{NetworkedPlayer, PlayerOptions};
 use clash::protocol::Message;
 use clash::{LobbyId, PlayerId, MAX_PLAYERS};
 use thiserror::Error;
@@ -17,7 +17,7 @@ pub enum LobbyError {
 }
 
 pub struct Lobby {
-    pub shared: SharedLobby,
+    pub shared: NetworkedLobby,
     pub sender: Sender<Message>,
     pub next_menu_order: u8,
 }
@@ -26,7 +26,7 @@ impl Lobby {
     pub fn new(new_options: LobbyOptions, lobby_id: LobbyId) -> Self {
         let (sender, _) = channel(100);
         Self {
-            shared: SharedLobby::new(lobby_id, new_options),
+            shared: NetworkedLobby::new(lobby_id, new_options),
             sender,
             next_menu_order: 0,
         }
@@ -68,7 +68,7 @@ impl Lobby {
         players.insert(player_id, self.shared.lobby_id);
 
         // TODO: Unhardcode player color
-        let mut player = SharedPlayer::new(PlayerOptions::default(), self.next_menu_order);
+        let mut player = NetworkedPlayer::new(PlayerOptions::default(), self.next_menu_order);
         player.options.color = clash::player::COLORS[self.shared.players.len()];
         self.next_menu_order += 1;
 

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -42,7 +42,7 @@ impl Lobby {
         }
     }
 
-    pub fn is_player_in_lobby(&mut self, player_id: &u32) -> bool {
+    pub fn is_player_in_lobby(&self, player_id: &u32) -> bool {
         self.shared.players.contains_key(player_id)
     }
 

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -1,6 +1,6 @@
 use clash::lobby::{GamePhase, LobbyOptions, NetworkedLobby};
+use clash::net::Message;
 use clash::player::{NetworkedPlayer, PlayerOptions};
-use clash::protocol::Message;
 use clash::{LobbyId, PlayerId, MAX_PLAYERS};
 use thiserror::Error;
 use tokio::sync::broadcast::Sender;

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use clash::{lobby::LobbyOptions, protocol::ProtocolError, LobbyId, PlayerId};
+use clash::{lobby::LobbyOptions, net::ProtocolError, LobbyId, PlayerId};
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod game_state;
 pub mod lobby;
+pub mod net;
 pub mod player;
-pub mod protocol;
 
 pub const MAX_PLAYERS: usize = 6;
 

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{game_state::GameState, player::SharedPlayer, LobbyId, PlayerId};
+use crate::{game_state::GameState, player::NetworkedPlayer, LobbyId, PlayerId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -26,16 +26,16 @@ pub enum GamePhase {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct SharedLobby {
+pub struct NetworkedLobby {
     pub game_state: GameState,
     pub lobby_id: LobbyId,
     pub options: LobbyOptions,
-    pub players: HashMap<PlayerId, SharedPlayer>,
+    pub players: HashMap<PlayerId, NetworkedPlayer>,
     pub game_phase: GamePhase,
     pub host_id: Option<PlayerId>,
 }
 
-impl SharedLobby {
+impl NetworkedLobby {
     pub fn new(lobby_id: u32, options: LobbyOptions) -> Self {
         Self {
             game_state: GameState::default(),

--- a/src/net/error.rs
+++ b/src/net/error.rs
@@ -1,0 +1,45 @@
+use crate::{LobbyId, PlayerId};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Error, Clone, Debug, Serialize, Deserialize)]
+pub enum ProtocolError {
+    #[error("Invalid Player ID {0:#X}")]
+    InvalidPlayerId(PlayerId),
+    #[error("Invalid Lobby ID {0:#X}")]
+    InvalidLobbyId(LobbyId),
+    #[error("Invalid Message")]
+    InvalidMessage,
+    // TODO: This probably shouldn't be an error
+    #[error("Player disconnected")]
+    Disconnected,
+    #[error("Client version '{0}' does not match server version '{1}'")]
+    VersionMismatch(String, String),
+}
+
+#[derive(Debug, Error)]
+pub enum FrameError {
+    #[error("Frame exceeded max length")]
+    FrameLength,
+    #[error("Full frame is not available yet.")]
+    FrameIncomplete,
+    #[error("Connection reset by peer")]
+    ConnectionReset,
+    #[error("I/O Error: {0}")]
+    Io(std::io::Error),
+    #[error("Serialization Error: {0}")]
+    Bincode(bincode::Error),
+}
+
+impl From<std::io::Error> for FrameError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<bincode::Error> for FrameError {
+    fn from(e: bincode::Error) -> Self {
+        Self::Bincode(e)
+    }
+}

--- a/src/net/message.rs
+++ b/src/net/message.rs
@@ -1,0 +1,30 @@
+use crate::lobby::{LobbyOptions, NetworkedLobby};
+use crate::player::PlayerOptions;
+use bfbb::{Level, Spatula};
+use serde::{Deserialize, Serialize};
+
+use super::ProtocolError;
+
+// TODO: Take more advantage of the type system (e.g. Client/Server messages)
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub enum Message {
+    Version { version: String },
+    Error { error: ProtocolError },
+    ConnectionAccept { player_id: u32 },
+    PlayerOptions { options: PlayerOptions },
+    GameHost,
+    GameJoin { lobby_id: u32 },
+    GameOptions { options: LobbyOptions },
+    GameLobbyInfo { lobby: NetworkedLobby },
+    GameBegin,
+    GameCurrentLevel { level: Option<Level> },
+    GameForceWarp { level: Level },
+    GameItemCollected { item: Item },
+    GameEnd,
+    GameLeave,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub enum Item {
+    Spatula(Spatula),
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,7 @@
+pub use connection::Connection;
+pub use error::{FrameError, ProtocolError};
+pub use message::{Item, Message};
+
+mod connection;
+mod error;
+mod message;

--- a/src/player.rs
+++ b/src/player.rs
@@ -19,14 +19,14 @@ pub struct PlayerOptions {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct SharedPlayer {
+pub struct NetworkedPlayer {
     pub options: PlayerOptions,
     pub current_level: Option<Level>,
     pub score: u8,
     pub menu_order: u8,
 }
 
-impl SharedPlayer {
+impl NetworkedPlayer {
     pub fn new(options: PlayerOptions, menu_order: u8) -> Self {
         Self {
             options,

--- a/src/player.rs
+++ b/src/player.rs
@@ -15,7 +15,6 @@ pub const COLORS: [(u8, u8, u8); 6] = [
 pub struct PlayerOptions {
     pub name: String,
     pub color: (u8, u8, u8),
-    // Other options?
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -38,7 +37,7 @@ impl NetworkedPlayer {
 }
 
 impl PlayerOptions {
-    pub fn color(&self) -> egui::Color32 {
-        egui::Color32::from_rgb(self.color.0, self.color.1, self.color.2)
+    pub fn color(&self) -> epaint::Color32 {
+        epaint::Color32::from_rgb(self.color.0, self.color.1, self.color.2)
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::{io::AsyncReadExt, io::AsyncWriteExt, io::BufWriter, net::TcpStream};
 
-use crate::lobby::{LobbyOptions, SharedLobby};
+use crate::lobby::{LobbyOptions, NetworkedLobby};
 use crate::player::PlayerOptions;
 use crate::{LobbyId, PlayerId};
 use bfbb::{Level, Spatula};
@@ -36,7 +36,7 @@ pub enum Message {
     GameHost,
     GameJoin { lobby_id: u32 },
     GameOptions { options: LobbyOptions },
-    GameLobbyInfo { lobby: SharedLobby },
+    GameLobbyInfo { lobby: NetworkedLobby },
     GameBegin,
     GameCurrentLevel { level: Option<Level> },
     GameForceWarp { level: Level },


### PR DESCRIPTION
This PR cleans up quite a few code quality issues and lays some groundwork for future expansions. The major changes are as follows:

- Changed `SharedPlayer` and `SharedLobby` to `NetworkedPlayer` and `NetworkedLobby`. I believe these names are more clear.
- Renamed shared lib `protocol` module to `net` and broke it down into multiple files.
- Removed `GameStateExt`. Firstly, the name was a misnomer, and secondly it didn't provide a nice way of implementing future game modes.
  - All networking remains unchanged, if future gamemodes require specialized network logic, we'll need to add a way to specialize it at that point.