### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: 'cargo' # See documentation for possible values
-    directory: '/client' # Location of package manifests
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'cargo' # See documentation for possible values
-    directory: '/server' # Location of package manifests
-    schedule:
-      interval: 'weekly'
-  - package-ecosystem: 'cargo' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Dependabot was complaining about the client and server packages not being in the workspace root. I believe that since `/` is a workspace it will automatically monitor all packages dependencies (we'll see if that's true).