### PR TITLE
Optimize CI build-times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --profile=ci --no-run
+          args: --profile=ci --no-run --locked
       - name: Test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  CARGO_INCREMENTAL: 0
   RUSTFLAGS: -D warnings
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 on: pull_request
 
 name: CI
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,16 @@ jobs:
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Run Tests
+      - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --profile ci
+          args: --profile=ci --no-run
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --profile=ci
       - name: Deny Clippy warnings
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: -D warnings
+
 jobs:
   ci:
     name: Clash
@@ -37,7 +40,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --tests --profile ci -- -D warnings
+          args: --profile=ci --tests
       - name: Verify formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --tests -- -D warnings
+          args: --tests --profile ci -- -D warnings
       - name: Verify formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,13 @@
 on: pull_request
 
-name: Continuous Integration
+name: CI
 
 jobs:
-  ci-matrix:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-
-    name: Continuous Integration - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  ci:
+    name: Clash
+    runs-on: ubuntu-latest
     steps:
       - name: Install C build-dependencies
-        if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt update -qq
           sudo apt install -y libxcb-shape0-dev libxcb-xfixes0-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1", features = [
     "time",
 ] }
 
-# Remove unneeded debug info from linux binaries
+# Remove unneeded debug info from linux release binaries
 [profile.release]
 strip = true
 
@@ -30,9 +30,10 @@ strip = true
 [profile.dev.package."*"]
 opt-level = 3
 
-# Don't optimize on CI though
+# Optimize CI for build-times
 [profile.ci]
 inherits = "dev"
+debug = 0
 
 [profile.ci.package."*"]
 opt-level = 0


### PR DESCRIPTION
I mistakenly left the CI profile off of the clippy command in CI, slowing down CI greatly. I removed the windows build since it's usually extremely slow compared to linux and we previously extracted the `bfbb` crate to it's own repo. The only windows-only code left AFAIK is the build script used to add the app icon. Additionally I set up concurrency groups to automatically cancel redundant workflows just to be nice to github.