### PR TITLE
Run ci on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
-on: pull_request
+on:
+  push:
+    branches: main
+  pull_request:
 
 name: CI
 concurrency:


### PR DESCRIPTION
We already only merge changes that pass ci, but this is a workaround to ensure that new PRs should always hit the build cache when CI runs.